### PR TITLE
Ability To Clear Existing Directories Rather Than Delete

### DIFF
--- a/product/dropkick/Configuration/Dsl/Files/CopyOptions.cs
+++ b/product/dropkick/Configuration/Dsl/Files/CopyOptions.cs
@@ -10,11 +10,13 @@
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the 
 // specific language governing permissions and limitations under the License.
+using System.Text.RegularExpressions;
 namespace dropkick.Configuration.Dsl.Files
 {
     public interface CopyOptions
     {
         CopyOptions To(string destinationPath);
         void DeleteDestinationBeforeDeploying();
+		void ClearFilesBeforeDeploying(Regex[] ignorePatterns);
     }
 }

--- a/product/dropkick/Configuration/Dsl/Files/ProtoCopyDirectoryTask.cs
+++ b/product/dropkick/Configuration/Dsl/Files/ProtoCopyDirectoryTask.cs
@@ -17,6 +17,7 @@ namespace dropkick.Configuration.Dsl.Files
     using FileSystem;
     using Tasks;
     using Tasks.Files;
+using System.Text.RegularExpressions;
 
     public class ProtoCopyDirectoryTask :
         BaseProtoTask,
@@ -27,6 +28,7 @@ namespace dropkick.Configuration.Dsl.Files
         readonly IList<string> _froms = new List<string>();
         DestinationCleanOptions _options = DestinationCleanOptions.None;
         string _to;
+		Regex[] _ignorePatterns = new Regex[] {};
 
         public ProtoCopyDirectoryTask(Path path)
         {
@@ -43,6 +45,16 @@ namespace dropkick.Configuration.Dsl.Files
         {
             _options = DestinationCleanOptions.Delete;
         }
+
+		/// <summary>
+		/// Clears the target directory before deploying, optionally ignoring some
+		/// files in the target directory (e.g. app_offline.htm);
+		/// </summary>
+		/// <param name="ignorePatterns">The files to ignore in the target directory.</param>
+		public void ClearFilesBeforeDeploying(Regex[] ignorePatterns)
+		{
+			_ignorePatterns = ignorePatterns;
+		}
 
         public void Include(string path)
         {
@@ -63,7 +75,7 @@ namespace dropkick.Configuration.Dsl.Files
 
             foreach (var f in _froms)
             {
-                var o = new CopyDirectoryTask(f, to, _options, _path);
+                var o = new CopyDirectoryTask(f, to, _options, _path, _ignorePatterns);
                 server.AddTask(o);
             }
         }

--- a/product/dropkick/Tasks/Files/BaseIoTask.cs
+++ b/product/dropkick/Tasks/Files/BaseIoTask.cs
@@ -60,7 +60,7 @@ namespace dropkick.Tasks.Files
             }
         }
 
-        protected void CopyDirectory(DeploymentResult result, DirectoryInfo source, DirectoryInfo destination, Regex[] ignorePatterns)
+        protected void CopyDirectory(DeploymentResult result, DirectoryInfo source, DirectoryInfo destination)
         {
             if (!destination.Exists)
             {
@@ -69,18 +69,12 @@ namespace dropkick.Tasks.Files
 
             // Copy all files.
 			FileInfo[] files = source.GetFiles();
-			
-            foreach (FileInfo file in files)
-            {
-				bool isIgnored = IsIgnored(ignorePatterns, file.Name);
 
-				if (!isIgnored)
-				{
-					string fileDestination = _path.Combine(destination.FullName, file.Name);
-
-					CopyFileToFile(result, file, new FileInfo(fileDestination));
-				}
-            }
+			foreach (FileInfo file in files)
+			{
+				string fileDestination = _path.Combine(destination.FullName, file.Name);
+				CopyFileToFile(result, file, new FileInfo(fileDestination));
+			}
 
             // Process subdirectories.
             DirectoryInfo[] dirs = source.GetDirectories();
@@ -90,7 +84,7 @@ namespace dropkick.Tasks.Files
                 string destinationDir = _path.Combine(destination.FullName, dir.Name);
 
                 // Call CopyDirectory() recursively.
-                CopyDirectory(result, dir, new DirectoryInfo(destinationDir), ignorePatterns);
+                CopyDirectory(result, dir, new DirectoryInfo(destinationDir));
             }
         }
 

--- a/product/dropkick/Tasks/Files/BaseIoTask.cs
+++ b/product/dropkick/Tasks/Files/BaseIoTask.cs
@@ -7,6 +7,9 @@ namespace dropkick.Tasks.Files
     using log4net;
     using ExtensionsToString = Magnum.Extensions.ExtensionsToString;
     using Path = FileSystem.Path;
+	using System.Text.RegularExpressions;
+	using System.Linq;
+	using System.Globalization;
 
     public abstract class BaseIoTask :
         BaseTask
@@ -57,7 +60,7 @@ namespace dropkick.Tasks.Files
             }
         }
 
-        protected void CopyDirectory(DeploymentResult result, DirectoryInfo source, DirectoryInfo destination)
+        protected void CopyDirectory(DeploymentResult result, DirectoryInfo source, DirectoryInfo destination, Regex[] ignorePatterns)
         {
             if (!destination.Exists)
             {
@@ -65,12 +68,18 @@ namespace dropkick.Tasks.Files
             }
 
             // Copy all files.
-            FileInfo[] files = source.GetFiles();
-            foreach (var file in files)
+			FileInfo[] files = source.GetFiles();
+			
+            foreach (FileInfo file in files)
             {
-                string fileDestination = _path.Combine(destination.FullName,file.Name);
+				bool isIgnored = IsIgnored(ignorePatterns, file.Name);
 
-                CopyFileToFile(result, file, new FileInfo(fileDestination));
+				if (!isIgnored)
+				{
+					string fileDestination = _path.Combine(destination.FullName, file.Name);
+
+					CopyFileToFile(result, file, new FileInfo(fileDestination));
+				}
             }
 
             // Process subdirectories.
@@ -81,9 +90,75 @@ namespace dropkick.Tasks.Files
                 string destinationDir = _path.Combine(destination.FullName, dir.Name);
 
                 // Call CopyDirectory() recursively.
-                CopyDirectory(result, dir, new DirectoryInfo(destinationDir));
+                CopyDirectory(result, dir, new DirectoryInfo(destinationDir), ignorePatterns);
             }
         }
+
+		/// <summary>
+		/// Determines whether a string matches the given ignore patterns.  This is used
+		/// to ignore files which shouldn't be copied from the source to target directories,
+		/// e.g. you may first place an App_Offline.htm file into the directory before copying
+		/// data to it.  You wouldn't want to delete the App_Offline.html file while copying files.
+		/// </summary>
+		/// <param name="ignorePatterns"></param>
+		/// <param name="fileName"></param>
+		/// <returns></returns>
+		private bool IsIgnored(Regex[] ignorePatterns, string fileName)
+		{
+			bool returnValue = false;
+
+			foreach (Regex ignorePattern in ignorePatterns)
+			{
+				if (ignorePattern.IsMatch(fileName))
+				{
+					returnValue = true;
+					break;
+				}
+			}
+
+			return returnValue;
+		}
+
+		/// <summary>
+		/// Clears the contents of a given directory.
+		/// </summary>
+		/// <param name="result">The Deployment results.</param>
+		/// <param name="directory">The directory to clear.</param>
+		protected void ClearDirectoryContents(DeploymentResult result, DirectoryInfo directory)
+		{
+			ClearDirectoryContents(result, directory, new Regex[] { });
+		}
+
+		/// <summary>
+		/// Clears the contents of a given directory.
+		/// </summary>
+		/// <param name="result">The Deployment results.</param>
+		/// <param name="directory">The directory to clear.</param>
+		/// <param name="ignorePatterns">Regular expressions which match the files to ignore, e.g. "[aA]pp_[Oo]ffline\.htm".</param>
+		protected void ClearDirectoryContents(DeploymentResult result, DirectoryInfo directory, Regex[] ignorePatterns)
+		{
+			if(ignorePatterns == null)
+			{
+				ignorePatterns = new Regex[] {};
+			}
+
+			result.Add(new DeploymentItem(DeploymentItemStatus.Good, string.Format(CultureInfo.InvariantCulture, "Clearing directory \"{0}\".", directory.Name)));
+
+			// Delete files.
+			FileInfo[] files = directory.GetFiles();
+			foreach(FileInfo file in files.Where(f => !IsIgnored(ignorePatterns, f.Name)))
+			{
+				File.Delete(file.FullName);
+			}
+
+			// Delete subdirectories.
+			foreach(DirectoryInfo subdirectory in directory.GetDirectories())
+			{
+				Directory.Delete(subdirectory.FullName, true);
+			}
+
+			result.Add(new DeploymentItem(DeploymentItemStatus.Good, string.Format(CultureInfo.InvariantCulture, "Directory \"{0}\" cleared.", directory.Name)));
+		}
 
         protected static void DeleteDestinationFirst(DirectoryInfo directory, DeploymentResult result)
         {

--- a/product/dropkick/Tasks/Files/CopyDirectoryTask.cs
+++ b/product/dropkick/Tasks/Files/CopyDirectoryTask.cs
@@ -17,6 +17,7 @@ namespace dropkick.Tasks.Files
     using DeploymentModel;
     using log4net;
     using Path = FileSystem.Path;
+	using System.Text.RegularExpressions;
 
     public class CopyDirectoryTask : BaseIoTask
     {
@@ -24,6 +25,7 @@ namespace dropkick.Tasks.Files
         readonly DestinationCleanOptions _options;
         string _from;
         string _to;
+		Regex[] _ignorePatterns = new Regex[] { };
 
         public CopyDirectoryTask(string @from, string to, DestinationCleanOptions options, Path path) : base(path)
         {
@@ -31,6 +33,15 @@ namespace dropkick.Tasks.Files
             _to = to;
             _options = options;
         }
+
+		public CopyDirectoryTask(string @from, string to, DestinationCleanOptions options, Path path, Regex[] ignorePatterns)
+			: base(path)
+		{
+			_from = from;
+			_to = to;
+			_options = options;
+			_ignorePatterns = ignorePatterns;
+		}
 
         #region Task Members
 
@@ -51,7 +62,7 @@ namespace dropkick.Tasks.Files
 
             if (_options == DestinationCleanOptions.Delete) DeleteDestinationFirst(new DirectoryInfo(_to), result);
 
-            CopyDirectory(result, new DirectoryInfo(_from), new DirectoryInfo(_to));
+            CopyDirectory(result, new DirectoryInfo(_from), new DirectoryInfo(_to), _ignorePatterns);
 
             result.AddGood(Name);
 

--- a/product/dropkick/Tasks/Files/CopyDirectoryTask.cs
+++ b/product/dropkick/Tasks/Files/CopyDirectoryTask.cs
@@ -60,9 +60,16 @@ namespace dropkick.Tasks.Files
             _from = _path.GetFullPath(_from);
             _to = _path.GetFullPath(_to);
 
-            if (_options == DestinationCleanOptions.Delete) DeleteDestinationFirst(new DirectoryInfo(_to), result);
+			if (_options == DestinationCleanOptions.Delete)
+			{
+				DeleteDestinationFirst(new DirectoryInfo(_to), result);
+			}
+			else if (_options == DestinationCleanOptions.Clear)
+			{
+				ClearDirectoryContents(result, new DirectoryInfo(_to));
+			}
 
-            CopyDirectory(result, new DirectoryInfo(_from), new DirectoryInfo(_to), _ignorePatterns);
+            CopyDirectory(result, new DirectoryInfo(_from), new DirectoryInfo(_to));
 
             result.AddGood(Name);
 

--- a/product/dropkick/Tasks/Files/DestinationCleanOptions.cs
+++ b/product/dropkick/Tasks/Files/DestinationCleanOptions.cs
@@ -3,6 +3,7 @@ namespace dropkick.Tasks.Files
     public enum DestinationCleanOptions
     {
         Delete,
+		Clear,
         None
     }
 }


### PR DESCRIPTION
I generally want to copy an App_Offline.htm file into the remote application to take it offline while I'm working, so I then want to clear the directory rather than outright deleting it, while maintaining the existence of the app_offline.htm so that the site stays down.

I can then copy my Website over, then delete the app_offline.htm file to bring it back online.
