### PR TITLE
Delete File Task

### DIFF
--- a/product/dropkick/Configuration/Dsl/Files/Extension.cs
+++ b/product/dropkick/Configuration/Dsl/Files/Extension.cs
@@ -69,5 +69,11 @@ namespace dropkick.Configuration.Dsl.Files
 			protoServer.RegisterProtoTask(proto);
 			return proto;
 		}
+
+		public static void DeleteFile(this ProtoServer protoServer, string file)
+		{
+			var proto = new ProtoDeleteFileTask(file);
+			protoServer.RegisterProtoTask(proto);
+		}
     }
 }

--- a/product/dropkick/Configuration/Dsl/Files/ProtoDeleteFileTask.cs
+++ b/product/dropkick/Configuration/Dsl/Files/ProtoDeleteFileTask.cs
@@ -1,0 +1,24 @@
+﻿namespace dropkick.Configuration.Dsl.Files
+{
+	using DeploymentModel;
+	using FileSystem;
+	using Tasks;
+	using Tasks.Files;
+
+	public class ProtoDeleteFileTask :
+		BaseProtoTask
+	{
+		readonly string _file;
+
+		public ProtoDeleteFileTask(string file)
+		{
+			_file = ReplaceTokens(file);
+		}
+
+		public override void RegisterRealTasks(PhysicalServer site)
+		{
+			string serverFileName = site.MapPath(_file);
+			site.AddTask(new DeleteFileTask(serverFileName));
+		}
+	}
+}

--- a/product/dropkick/Tasks/Files/DeleteFileTask.cs
+++ b/product/dropkick/Tasks/Files/DeleteFileTask.cs
@@ -1,0 +1,54 @@
+﻿namespace dropkick.Tasks.Files
+{
+	using System.IO;
+	using DeploymentModel;
+	using Path = FileSystem.Path;
+
+	public class DeleteFileTask : Task
+	{
+		string _fileName;
+
+		public DeleteFileTask(string fileName)
+		{
+			_fileName = fileName;
+		}
+
+		public string Name
+		{
+			get { return "Deleting file '{0}'".FormatWith(_fileName); }
+		}
+
+		public DeploymentResult VerifyCanRun()
+		{
+			var result = new DeploymentResult();
+
+			if (File.Exists(System.IO.Path.GetFileName(_fileName)))
+			{
+				result.AddGood(string.Format("{0} exists and will be deleted.", _fileName));
+			}
+			else
+			{
+				result.AddGood(string.Format("{0} does not exist, so cannot be deleted.", _fileName));
+			}
+
+			return result;
+		}
+
+		public DeploymentResult Execute()
+		{
+			var result = new DeploymentResult();
+
+			if (File.Exists(_fileName))
+			{
+				File.Delete(_fileName);
+				result.AddGood(string.Format("{0} exists and was deleted.", _fileName));
+			}
+			else
+			{
+				result.AddGood(string.Format("{0} does not exist, so cannot be deleted.", _fileName));
+			}
+
+			return result;
+		}
+	}
+}

--- a/product/dropkick/dropkick.csproj
+++ b/product/dropkick/dropkick.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Configuration\Dsl\CommandLine\CommandLineOptions.cs" />
     <Compile Include="Configuration\Dsl\CommandLine\ProtoCommandLineTask.cs" />
     <Compile Include="Configuration\Dsl\Files\FileCopyOptions.cs" />
+    <Compile Include="Configuration\Dsl\Files\ProtoDeleteFileTask.cs" />
     <Compile Include="Configuration\Dsl\Files\ProtoEncryptAppConfigTask.cs" />
     <Compile Include="Configuration\Dsl\Files\ProtoUnzipArchiveTask.cs" />
     <Compile Include="Configuration\Dsl\Files\UnzipOptions.cs" />
@@ -139,6 +140,7 @@
     <Compile Include="Configuration\Dsl\Security\Msmq\ProtoSetSensibleMsmqDefaults.cs" />
     <Compile Include="Tasks\Files\BaseIoTask.cs" />
     <Compile Include="Tasks\Files\CopyOptions.cs" />
+    <Compile Include="Tasks\Files\DeleteFileTask.cs" />
     <Compile Include="Tasks\Files\EmptyFolderTask.cs" />
     <Compile Include="Configuration\Dsl\Files\ProtoEmptyFolderTask.cs" />
     <Compile Include="Configuration\Dsl\Security\Msmq\ProtoMsmqGrantWriteTask.cs" />


### PR DESCRIPTION
I've added a DeleteFile task to DropKick. I use it to delete files on the target server, e.g. put App_Offline.htm in place, then deploy updated application, make configuration changes etc., then delete App_Offline.htm to bring it all back online.
