### PR TITLE
Fix for #36

### DIFF
--- a/product/dropkick/DeploymentModel/DeploymentPlan.cs
+++ b/product/dropkick/DeploymentModel/DeploymentPlan.cs
@@ -63,6 +63,8 @@ namespace dropkick.DeploymentModel
                 deploymentResult.MergedWith(o);
                 if (o.ContainsError())
                 {
+                    //display errors!
+                    DisplayResults(o);
                     //stop. report verify error.
                     return;
                 }

--- a/product/dropkick/Tasks/Files/CopyFileTask.cs
+++ b/product/dropkick/Tasks/Files/CopyFileTask.cs
@@ -45,8 +45,10 @@ namespace dropkick.Tasks.Files
             _to = _path.GetFullPath(_to);
 
             ValidatePaths(result);
-
-            result.AddGood(Name);
+            if(!result.ContainsError()) {
+                //don't report back 'good' on errors
+                result.AddGood(Name);
+            }
 
             return result;
         }
@@ -59,11 +61,12 @@ namespace dropkick.Tasks.Files
             _to = _path.GetFullPath(_to);
 
             ValidatePaths(result);
+            if(!result.ContainsError()) {
+                //don't continue on errors
+                CopyFile(result, _newFileName, _from, _to);
 
-            CopyFile(result, _newFileName, _from, _to);
-
-            result.AddGood(Name);
-
+                result.AddGood(Name);
+            }
             return result;
         }
 


### PR DESCRIPTION
Change in product/dropkick/DeploymentModel/DeploymentPlan.cs is the actual fix for #36.

Changes in product/dropkick/Tasks/Files/CopyFileTask.cs are not exactly releated to #36, but if errors found during verification, I think it should not try to execute the actual task, and do `result.AddGood(Name);`.
