### PR TITLE
Added namespace support to the XmlPoke task

### DIFF
--- a/product/dropkick.tests/Tasks/Xml/Context/TestWithNamespace.xml
+++ b/product/dropkick.tests/Tasks/Xml/Context/TestWithNamespace.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration xmlns="http://example.com/schemas/test">
+  <connectionStrings>
+    <add name="bob" connectionString="Data Source=(local);Initial Catalog=bob;Integrated Security=True;Pooling=false;Connection Timeout=600" providerName="System.Data.SqlClient" />
+    <add name="nancy" connectionString="Data Source=(local);Initial Catalog=Nancy;Integrated Security=True;Pooling=false;Connection Timeout=600" providerName="System.Data.SqlClient" />
+  </connectionStrings>
+</configuration>

--- a/product/dropkick.tests/Tasks/Xml/Context/XmlContextResult.cs
+++ b/product/dropkick.tests/Tasks/Xml/Context/XmlContextResult.cs
@@ -10,5 +10,13 @@
   </connectionStrings>
 </configuration>";
 
+        public static string ResultWithNamespace = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration xmlns=""http://example.com/schemas/test"">
+  <connectionStrings>
+    <add name=""bob"" connectionString=""bob"" providerName=""System.Data.SqlClient"" />
+    <add name=""nancy"" connectionString=""Data Source=(local);Initial Catalog=Nancy;Integrated Security=True;Pooling=false;Connection Timeout=600"" providerName=""System.Data.SqlClient"" />
+  </connectionStrings>
+</configuration>";
+
     }
 }

--- a/product/dropkick.tests/Tasks/Xml/XmlPokeTaskSpecs.cs
+++ b/product/dropkick.tests/Tasks/Xml/XmlPokeTaskSpecs.cs
@@ -15,10 +15,17 @@ namespace dropkick.tests.Tasks.Xml
             protected DeploymentResult result;
             protected XmlPokeTask task;
             protected string file_path = @".\Tasks\Xml\Context\Test.xml";
+            protected string file_path_with_namespace = @".\Tasks\Xml\Context\TestWithNamespace.xml";
 
-            public override void Context()
+            public override void Because()
             {
-                result = new DeploymentResult();
+                result = task.Execute();
+            }
+
+            [Fact]
+            public void should_execute_successfully()
+            {
+                System.Console.WriteLine(result.ToString());
             }
         }
 
@@ -35,17 +42,6 @@ namespace dropkick.tests.Tasks.Xml
                 task = new XmlPokeTask(file_path, replacement_items, new DotNetPath());
             }
 
-            public override void Because()
-            {
-                result = task.Execute();
-            }
-
-            [Fact]
-            public void should_execute_successfully()
-            {
-                System.Console.WriteLine(result.ToString());
-            }
-
             [Fact]
             public void should_have_updated_the_file()
             {
@@ -55,6 +51,26 @@ namespace dropkick.tests.Tasks.Xml
         }
 
 
+        [ConcernFor("Xml")]
+        [Category("Integration")]
+        public class when_updating_the_settings_in_an_xml_file_with_namespaces : XmlPokeTaskSpecsBase
+        {
+            protected IDictionary<string, string> replacement_items = new Dictionary<string, string>();
+            protected IDictionary<string, string> namespace_prefixes = new Dictionary<string, string> {{"test", "http://example.com/schemas/test"}};
+
+            public override void Context()
+            {
+                replacement_items.Add("//test:configuration/test:connectionStrings/test:add[@name='bob']/@connectionString", "bob");
+                task = new XmlPokeTask(file_path_with_namespace, replacement_items, new DotNetPath(), namespace_prefixes);
+            }
+
+            [Fact]
+            public void should_have_updated_the_file()
+            {
+                string updated_text = File.ReadAllText(file_path_with_namespace);
+                updated_text.ShouldBeEqualTo(XmlContextResult.ResultWithNamespace);
+            }
+        }
     }
 
 }

--- a/product/dropkick.tests/dropkick.tests.csproj
+++ b/product/dropkick.tests/dropkick.tests.csproj
@@ -181,6 +181,9 @@
     <Content Include="Tasks\MsSql\test.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Tasks\Xml\Context\TestWithNamespace.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Tasks\Xml\Context\Test.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/product/dropkick/Configuration/Dsl/Xml/Extension.cs
+++ b/product/dropkick/Configuration/Dsl/Xml/Extension.cs
@@ -10,6 +10,9 @@
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the 
 // specific language governing permissions and limitations under the License.
+
+using System.Collections.Generic;
+
 namespace dropkick.Configuration.Dsl.Xml
 {
     public static class Extension
@@ -17,6 +20,13 @@ namespace dropkick.Configuration.Dsl.Xml
         public static XmlPokeOptions XmlPoke(this ProtoServer protoServer, string filePath)
         {
             var proto = new ProtoXmlPokeTask(filePath);
+            protoServer.RegisterProtoTask(proto);
+            return proto;
+        }
+
+        public static XmlPokeOptions XmlPoke(this ProtoServer protoServer, string filePath, IDictionary<string, string> namespacePrefixes)
+        {
+            var proto = new ProtoXmlPokeTask(filePath, namespacePrefixes);
             protoServer.RegisterProtoTask(proto);
             return proto;
         }

--- a/product/dropkick/Configuration/Dsl/Xml/ProtoXmlPokeTask.cs
+++ b/product/dropkick/Configuration/Dsl/Xml/ProtoXmlPokeTask.cs
@@ -23,11 +23,18 @@ namespace dropkick.Configuration.Dsl.Xml
         XmlPokeOptions
     {
         private readonly string _filePath;
+        private IDictionary<string, string> _namespacePrefixes; 
         private IDictionary<string, string> _items = new Dictionary<string, string>();
 
         public ProtoXmlPokeTask(string filePath)
+            : this(filePath, null)
+        {
+        }
+
+        public ProtoXmlPokeTask(string filePath, IDictionary<string, string> namespacePrefixes)
         {
             _filePath = ReplaceTokens(filePath);
+            _namespacePrefixes = namespacePrefixes ?? new Dictionary<string, string>();
         }
 
         public XmlPokeOptions Set(string xPath, string value)
@@ -50,7 +57,7 @@ namespace dropkick.Configuration.Dsl.Xml
         {
             string filePath = site.MapPath(_filePath);
 
-            var o = new XmlPokeTask(filePath, _items, new DotNetPath());
+            var o = new XmlPokeTask(filePath, _items, new DotNetPath(), _namespacePrefixes);
             site.AddTask(o);
         }
     }


### PR DESCRIPTION
Hi there,

Thanks for creating a great tool - no more msdeploy for us ;-)! We stumbled across an issue, though, while building a deployment with dropkick: The XmlPoke task doesn't take xml namespaces into account, so we were out of luck in updating an xml file where namespaces were necessary. It was a joy to find that the source was easily readable and hackable :), so we took the liberty to extend the task.

With this extension, it's possible to pass a dictionary of namespace prefixes/urls to the XmlPoke extension method to enable namespace prefixing in the xpath queries (see enclosed test for an example).

This pull request contains our simple fix to add namespace support to XmlPoke. It adds one method overload to the public api. Don't hesitate to comment or request changes/improvements.

All the best,

steinjak
