### PR TITLE
setting RemoteCommandLine.Machine to PhysicalServer.Name

### DIFF
--- a/product/dropkick/Configuration/Dsl/CommandLine/ProtoCommandLineTask.cs
+++ b/product/dropkick/Configuration/Dsl/CommandLine/ProtoCommandLineTask.cs
@@ -67,7 +67,8 @@ namespace dropkick.Configuration.Dsl.CommandLine
                           {
                               Args = _args,
                               ExecutableIsLocatedAt = _path,
-                              WorkingDirectory = _workingDirectory
+                              WorkingDirectory = _workingDirectory,
+                              Machine = s.Name
                           });
         }
     }


### PR DESCRIPTION
The `ProtoCommandLineTask` didn't set `Machine` on `RemoteCommandLineTask` causing exception to be thrown upon `WmiProcess.Run`. Setting `RemoteCommandLineTask.Machine` to `PhysicalServer.Name` seems to be appropriate.
