### PR TITLE
LocalCommandLineTask uses WorkingDirectory instead of ExecutableIsLocatedAt

### DIFF
--- a/product/dropkick.tests/Tasks/Console/PingTest.cs
+++ b/product/dropkick.tests/Tasks/Console/PingTest.cs
@@ -1,9 +1,12 @@
 namespace dropkick.tests.Tasks.Console
 {
+    using System;
     using dropkick.DeploymentModel;
     using dropkick.Tasks.CommandLine;
     using FileSystem;
     using NUnit.Framework;
+    using Path = System.IO.Path;
+    using System.Linq;
 
     [TestFixture]
     public class PingTest
@@ -28,6 +31,20 @@ namespace dropkick.tests.Tasks.Console
             Assert.AreEqual(1, r.Results.Count);
 
             //Assert.Contains(vi, r.Results);
+        }
+
+        [Test]
+        public void VerifyCanRunWithExecutablePathSet()
+        {
+            var t = new LocalCommandLineTask(new DotNetPath(), "ping")
+            {
+                ExecutableIsLocatedAt =
+                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "system32"),
+                    Args = "localhost"
+            };
+
+            var result = t.Execute();
+            result.Results.Select(r=> r.Status).ToList().ShouldContain(DeploymentItemStatus.Good);
         }
     }
 }

--- a/product/dropkick/Tasks/CommandLine/LocalCommandLineTask.cs
+++ b/product/dropkick/Tasks/CommandLine/LocalCommandLineTask.cs
@@ -75,7 +75,7 @@ namespace dropkick.Tasks.CommandLine
 
             if (!string.IsNullOrEmpty(WorkingDirectory)) psi.WorkingDirectory = WorkingDirectory;
 
-            psi.FileName = _path.Combine(WorkingDirectory, Command);
+            psi.FileName = _path.Combine(ExecutableIsLocatedAt, Command);
 
             string output;
             try


### PR DESCRIPTION
`LocalCommandLineTask` used `WorkingDirectory` to build `ProcessStartInfo.FileName` to be executed.  I believe the `ExecutableIsLocatedAt` should be used instead.
