### PR TITLE
Load Deployment Assembly with Assembly.LoadFrom instead of Assembly.LoadFile

### DIFF
--- a/product/dropkick/Engine/DeploymentFinders/AssemblyWasSpecifiedAssumingOnlyOneDeploymentClass.cs
+++ b/product/dropkick/Engine/DeploymentFinders/AssemblyWasSpecifiedAssumingOnlyOneDeploymentClass.cs
@@ -42,7 +42,7 @@ namespace dropkick.Engine.DeploymentFinders
 
             try
             {
-                var asm = Assembly.LoadFile(path);
+                var asm = Assembly.LoadFrom(path);
                 var foundDeploymentTypes = asm.GetTypes().Where(t => typeof (Deployment).IsAssignableFrom(t)).ToList();
 
                 if(foundDeploymentTypes.Count() > 1) throw new DeploymentConfigurationException("There was more than one deployment in the assembly '{0}'".FormatWith(assemblyName));


### PR DESCRIPTION
Hi guys,

So this line is the problem:
https://github.com/chucknorris/dropkick/blob/master/product/dropkick/Engine/DeploymentFinders/AssemblyWasSpecifiedAssumingOnlyOneDeploymentClass.cs#L45

In that line, once it have the path to DLL that contains the deployment code, it calls Assembly.LoadFile to load it. The problem I ran into is that this DLL references a few more DLLs, which are colocated with the deployment DLL, and LoadFile will not load those dependencies automatically. It will assume that all dependencies are in the current executing directory (where ever dk.exe is located) which does not have the dependencies. For a cutting edge explanation, here is an 11 year old blog post: http://blogs.msdn.com/b/suzcook/archive/2003/09/19/loadfile-vs-loadfrom.aspx

This a key difference between LoadFrom and LoadFile. LoadFrom will load the dependencies colocated with the deployment DLL, but LoadFile will not.

In my case, i'm using a copy of dk.exe sitting in a single directory, and then using that to execute a bunch of deployments from other directories, so it's not practical to put all of the dependency DLLs in the same directory as dk.exe.

Obviously in my case it's easier to change LoadFile to LoadFrom so that the dependencies will automatically get loaded. However, I wasn't sure if LoadFile was used intentionally because the deployemtn DLL in turn is also going to reference dropkick.dll, and you wanted to make sure that the correct dk.exe dll version was used. However if they actually was a breaking mismatch in the dropkick.dll versions, I'm guessing that it burst into flames with some gory error messages anyway, elegantly telling the user that they have a problem.

(Originally discussed here: https://github.com/chucknorris/dropkick/issues/61) 

Thanks
